### PR TITLE
Add support for aarch64 package builds

### DIFF
--- a/vmagent.spec
+++ b/vmagent.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmagent
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: vmagent is a tiny but mighty agent which helps you collect metrics from
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmagent.spec
+++ b/vmagent.spec
@@ -5,7 +5,7 @@
 
 Name:    vmagent
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: vmagent is a tiny but mighty agent which helps you collect metrics from various sources and store them in VictoriaMetrics or any other Prometheus-compatible storage systems that support the remote_write protocol.
 
 Group:   Development Tools

--- a/vmalert.spec
+++ b/vmalert.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmalert
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: vmalert executes a list of the given alerting or recording rules agains
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmalert.spec
+++ b/vmalert.spec
@@ -5,7 +5,7 @@
 
 Name:    vmalert
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: vmalert executes a list of the given alerting or recording rules against configured address. It is heavily inspired by Prometheus implementation and aims to be compatible with its syntax.
 
 Group:   Development Tools

--- a/vmauth.spec
+++ b/vmauth.spec
@@ -5,7 +5,7 @@
 
 Name:    vmauth
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: vmauth executes a list of the given alerting or recording rules against configured address. It is heavily inspired by Prometheus implementation and aims to be compatible with its syntax.
 
 Group:   Development Tools

--- a/vmauth.spec
+++ b/vmauth.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmauth
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: vmauth executes a list of the given alerting or recording rules against
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmbackup.spec
+++ b/vmbackup.spec
@@ -5,7 +5,7 @@
 
 Name:    vmbackup
 Version: 1.99.0
-Release: 1
+Release: 2
 Summary: vmbackup creates VictoriaMetrics data backups from instant snapshots.
 
 Group:   Development Tools

--- a/vmbackup.spec
+++ b/vmbackup.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmbackup
 Version: 1.99.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: vmbackup creates VictoriaMetrics data backups from instant snapshots.
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vmctl.spec
+++ b/vmctl.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmctl
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: VictoriaMetrics command-line tool
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vmctl.spec
+++ b/vmctl.spec
@@ -5,7 +5,7 @@
 
 Name:    vmctl
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: VictoriaMetrics command-line tool
 
 Group:   Development Tools

--- a/vminsert.spec
+++ b/vminsert.spec
@@ -5,7 +5,7 @@
 
 Name:    vminsert
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary:  accepts the ingested data and spreads it among vmstorage nodes according to consistent hashing over metric name and all its labels
 
 Group:   Development Tools

--- a/vminsert.spec
+++ b/vminsert.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vminsert
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary:  accepts the ingested data and spreads it among vmstorage nodes accordi
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-%{release_arch}-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf
@@ -26,8 +31,8 @@ BuildRequires: systemd
 vminsert accepts the ingested data and spreads it among vmstorage nodes according to consistent hashing over metric name and all its labels
 
 %prep
-curl -L %{url} > victoria-metrics-amd64-cluster.tar.gz
-tar -zxf victoria-metrics-amd64-cluster.tar.gz
+curl -L %{url} > victoria-metrics-%{release_arch}-cluster.tar.gz
+tar -zxf victoria-metrics-%{release_arch}-cluster.tar.gz
 
 %install
 %{__install} -m 0755 -d %{buildroot}%{_bindir}

--- a/vmrestore.spec
+++ b/vmrestore.spec
@@ -5,7 +5,7 @@
 
 Name:    vmrestore
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: vmrestore restores data from backups created by vmbackup. VictoriaMetrics v1.29.0 and newer versions must be used for working with the restored data.
 
 Group:   Development Tools

--- a/vmrestore.spec
+++ b/vmrestore.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmrestore
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: vmrestore restores data from backups created by vmbackup. VictoriaMetri
 
 Group:   Development Tools
 License: ASL 2.0
-URL:     https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
+URL:     https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vmselect.spec
+++ b/vmselect.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmselect
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary:  accepts the ingested data and spreads it among vmselect nodes accordin
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-%{release_arch}-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf
@@ -26,8 +31,8 @@ BuildRequires: systemd
 vmselect accepts the ingested data and spreads it among vmselect nodes according to consistent hashing over metric name and all its labels
 
 %prep
-curl -L %{url} > victoria-metrics-amd64-cluster.tar.gz
-tar -zxf victoria-metrics-amd64-cluster.tar.gz
+curl -L %{url} > victoria-metrics-%{release_arch}-cluster.tar.gz
+tar -zxf victoria-metrics-%{release_arch}-cluster.tar.gz
 
 %install
 %{__install} -m 0755 -d %{buildroot}%{_bindir}

--- a/vmselect.spec
+++ b/vmselect.spec
@@ -5,7 +5,7 @@
 
 Name:    vmselect
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary:  accepts the ingested data and spreads it among vmselect nodes according to consistent hashing over metric name and all its labels
 
 Group:   Development Tools

--- a/vmsingle.spec
+++ b/vmsingle.spec
@@ -5,7 +5,7 @@
 
 Name:    vmsingle
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary: The best long-term remote storage for Prometheus
 
 Group:   Development Tools

--- a/vmsingle.spec
+++ b/vmsingle.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmsingle
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary: The best long-term remote storage for Prometheus
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-%{release_arch}-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: vmsingle.conf

--- a/vmstorage.spec
+++ b/vmstorage.spec
@@ -1,3 +1,8 @@
+%define release_arch amd64
+%ifarch aarch64
+%define release_arch arm64
+%endif
+
 Name:    vmstorage
 Version: 1.102.0
 Release: 1
@@ -5,7 +10,7 @@ Summary:  accepts the ingested data and spreads it among vmstorage nodes accordi
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-%{release_arch}-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf
@@ -26,8 +31,8 @@ BuildRequires: systemd
 vmstorage accepts the ingested data and spreads it among vmstorage nodes according to consistent hashing over metric name and all its labels
 
 %prep
-curl -L %{url} > victoria-metrics-amd64-cluster.tar.gz
-tar -zxf victoria-metrics-amd64-cluster.tar.gz
+curl -L %{url} > victoria-metrics-%{release_arch}-cluster.tar.gz
+tar -zxf victoria-metrics-%{release_arch}-cluster.tar.gz
 
 %install
 %{__install} -m 0755 -d %{buildroot}%{_bindir}

--- a/vmstorage.spec
+++ b/vmstorage.spec
@@ -5,7 +5,7 @@
 
 Name:    vmstorage
 Version: 1.102.0
-Release: 1
+Release: 2
 Summary:  accepts the ingested data and spreads it among vmstorage nodes according to consistent hashing over metric name and all its labels
 
 Group:   Development Tools


### PR DESCRIPTION
VictoriaMetrics supports ARM64 (aarch64), but currently the RPMs are only built for x86_64 (amd64). It would be useful for my use-case to have an aarch64 RPM available for installation on aarch64 systems.

I've bumped the release here, as the specfile has changed -- if this is something you'd rather do on merge, I can rebase and remove that commit if necessary!